### PR TITLE
fixed (typo?) in Op_SBC, it now passes Klaus Dormann's actual test suite

### DIFF
--- a/mos6502.cpp
+++ b/mos6502.cpp
@@ -1214,7 +1214,7 @@ void mos6502::Op_SBC(uint16_t src)
 	
     if (IF_DECIMAL())
     {
-    	if ( ((A & 0x0F) - (IF_CARRY() ? 0 : 1)) < (src & 0x0F)) tmp -= 6;
+    	if ( ((A & 0x0F) - (IF_CARRY() ? 0 : 1)) < (m & 0x0F)) tmp -= 6;
         if (tmp > 0x99)
         {
         	tmp -= 0x60;


### PR DESCRIPTION
the decimal subtraction didn't pass Klaus' tests and Bruce Clark's test neither:

sed      ; Decimal mode (BCD subtraction: 12 - 21)
sec
lda #$12
sbc #$21 

expected after this instruction, C = 0, A = $91 but A was $EB (or something).

Looks like a typo.
