### PR TITLE
Add support for fixed "CMOS" indirect JMP

### DIFF
--- a/mos6502.cpp
+++ b/mos6502.cpp
@@ -591,8 +591,13 @@ uint16_t mos6502::Addr_ABI()
 	abs = (addrH << 8) | addrL;
 	
 	effL = Read(abs);
+
+#ifndef CMOS_INDIRECT_JMP_FIX
 	effH = Read((abs & 0xFF00) + ((abs + 1) & 0x00FF) );
-	
+#else
+	effH = Read(abs + 1);
+#endif
+
 	addr = effL + 0x100 * effH;
 	
 	return addr;


### PR DESCRIPTION
CMOS derivates of the MOS 6502 such as the 65C02 fixed the indirect jump on LSB addr xxFF bug, amongst fixing other errata. This commit adds a preprocessor option to use the new 'fixed' CMOS indirect JMP.