### PR TITLE
add RunEternally() & remove unused `#include <iostream>` & remove `using namespace std; & move macros & member initialization into mos6502.cpp

### DIFF
--- a/mos6502.cpp
+++ b/mos6502.cpp
@@ -1,7 +1,38 @@
-
 #include "mos6502.h"
 
+#define NEGATIVE  0x80
+#define OVERFLOW  0x40
+#define CONSTANT  0x20
+#define BREAK     0x10
+#define DECIMAL   0x08
+#define INTERRUPT 0x04
+#define ZERO      0x02
+#define CARRY     0x01
+
+#define SET_NEGATIVE(x) (x ? (status |= NEGATIVE) : (status &= (~NEGATIVE)) )
+#define SET_OVERFLOW(x) (x ? (status |= OVERFLOW) : (status &= (~OVERFLOW)) )
+//#define SET_CONSTANT(x) (x ? (status |= CONSTANT) : (status &= (~CONSTANT)) )
+//#define SET_BREAK(x) (x ? (status |= BREAK) : (status &= (~BREAK)) )
+#define SET_DECIMAL(x) (x ? (status |= DECIMAL) : (status &= (~DECIMAL)) )
+#define SET_INTERRUPT(x) (x ? (status |= INTERRUPT) : (status &= (~INTERRUPT)) )
+#define SET_ZERO(x) (x ? (status |= ZERO) : (status &= (~ZERO)) )
+#define SET_CARRY(x) (x ? (status |= CARRY) : (status &= (~CARRY)) )
+
+#define IF_NEGATIVE() ((status & NEGATIVE) ? true : false)
+#define IF_OVERFLOW() ((status & OVERFLOW) ? true : false)
+#define IF_CONSTANT() ((status & CONSTANT) ? true : false)
+#define IF_BREAK() ((status & BREAK) ? true : false)
+#define IF_DECIMAL() ((status & DECIMAL) ? true : false)
+#define IF_INTERRUPT() ((status & INTERRUPT) ? true : false)
+#define IF_ZERO() ((status & ZERO) ? true : false)
+#define IF_CARRY() ((status & CARRY) ? true : false)
+
 mos6502::mos6502(BusRead r, BusWrite w)
+	: reset_A(0x00)
+    , reset_X(0x00)
+    , reset_Y(0x00)
+    , reset_sp(0xFD)
+    , reset_status(CONSTANT)
 {
 	Write = (BusWrite)w;
 	Read = (BusRead)r;
@@ -906,6 +937,24 @@ void mos6502::Run(
 		cyclesRemaining -=
 			cycleMethod == CYCLE_COUNT        ? instr.cycles
 			/* cycleMethod == INST_COUNT */   : 1;
+	}
+}
+
+void mos6502::RunEternally()
+{
+	uint8_t opcode;
+	Instr instr;
+
+	while(!illegalOpcode)
+	{
+		// fetch
+		opcode = Read(pc++);
+
+		// decode
+		instr = InstrTable[opcode];
+
+		// execute
+		Exec(instr);
 	}
 }
 

--- a/mos6502.h
+++ b/mos6502.h
@@ -7,49 +7,17 @@
 //============================================================================
 
 #pragma once
-
-#include <iostream>
 #include <stdint.h>
-using namespace std;
-
-#define NEGATIVE  0x80
-#define OVERFLOW  0x40
-#define CONSTANT  0x20
-#define BREAK     0x10
-#define DECIMAL   0x08
-#define INTERRUPT 0x04
-#define ZERO      0x02
-#define CARRY     0x01
-
-#define SET_NEGATIVE(x) (x ? (status |= NEGATIVE) : (status &= (~NEGATIVE)) )
-#define SET_OVERFLOW(x) (x ? (status |= OVERFLOW) : (status &= (~OVERFLOW)) )
-//#define SET_CONSTANT(x) (x ? (status |= CONSTANT) : (status &= (~CONSTANT)) )
-//#define SET_BREAK(x) (x ? (status |= BREAK) : (status &= (~BREAK)) )
-#define SET_DECIMAL(x) (x ? (status |= DECIMAL) : (status &= (~DECIMAL)) )
-#define SET_INTERRUPT(x) (x ? (status |= INTERRUPT) : (status &= (~INTERRUPT)) )
-#define SET_ZERO(x) (x ? (status |= ZERO) : (status &= (~ZERO)) )
-#define SET_CARRY(x) (x ? (status |= CARRY) : (status &= (~CARRY)) )
-
-#define IF_NEGATIVE() ((status & NEGATIVE) ? true : false)
-#define IF_OVERFLOW() ((status & OVERFLOW) ? true : false)
-#define IF_CONSTANT() ((status & CONSTANT) ? true : false)
-#define IF_BREAK() ((status & BREAK) ? true : false)
-#define IF_DECIMAL() ((status & DECIMAL) ? true : false)
-#define IF_INTERRUPT() ((status & INTERRUPT) ? true : false)
-#define IF_ZERO() ((status & ZERO) ? true : false)
-#define IF_CARRY() ((status & CARRY) ? true : false)
-
-
 
 class mos6502
 {
 private:
     // register reset values
-    uint8_t reset_A = 0x00;
-    uint8_t reset_X = 0x00;
-    uint8_t reset_Y = 0x00;
-    uint8_t reset_sp = 0xFD;
-    uint8_t reset_status = CONSTANT;
+    uint8_t reset_A;
+    uint8_t reset_X;
+    uint8_t reset_Y;
+    uint8_t reset_sp;
+    uint8_t reset_status;
 
 	// registers
 	uint8_t A; // accumulator
@@ -197,6 +165,10 @@ public:
 		int32_t cycles,
 		uint64_t& cycleCount,
 		CycleMethod cycleMethod = CYCLE_COUNT);
+	void RunEternally(); // until it encounters a illegal opcode
+						 // useful when running e.g. MOS Monitor
+						 // no need to worry about cycle exhaus-
+						 // tion
     uint16_t GetPC();
     uint8_t GetS();
     uint8_t GetP();


### PR DESCRIPTION
1. add RunEternally() to eliminate the worry that the emulation may stop on exhaustion of cycles. this is useful when emulating a program with a dead loop. e.g. WOZ Monitor.
2. remove unused `#include <iostream>` & remove `using namespace std;` it's never used, and it's dangerous to write `using namespace`s in header files.
3. move macros & member initialization into mos6502.cpp. so macros wont conflict with other headers in a real project. member initialization referenced to a one of the macros, and thus might as well move member initialization to mos6502.cpp.