### PR TITLE
Clock Cycle Callback

### DIFF
--- a/mos6502.cpp
+++ b/mos6502.cpp
@@ -899,7 +899,7 @@ void mos6502::IRQ()
 		StackPush((status & ~BREAK) | CONSTANT);
 		SET_INTERRUPT(1);
 
-		// load PC from reset vector
+		// load PC from interrupt request vector
 		uint8_t pcl = Read(irqVectorL);
 		uint8_t pch = Read(irqVectorH);
 		pc = (pch << 8) + pcl;
@@ -915,7 +915,7 @@ void mos6502::NMI()
 	StackPush((status & ~BREAK) | CONSTANT);
 	SET_INTERRUPT(1);
 
-	// load PC from reset vector
+	// load PC from non-maskable interrupt vector
 	uint8_t pcl = Read(nmiVectorL);
 	uint8_t pch = Read(nmiVectorH);
 	pc = (pch << 8) + pcl;

--- a/mos6502.cpp
+++ b/mos6502.cpp
@@ -29,7 +29,7 @@
 
 mos6502::Instr mos6502::InstrTable[256];
 
-mos6502::mos6502(BusRead r, BusWrite w)
+mos6502::mos6502(BusRead r, BusWrite w, ClockCycle c)
 	: reset_A(0x00)
     , reset_X(0x00)
     , reset_Y(0x00)
@@ -38,6 +38,7 @@ mos6502::mos6502(BusRead r, BusWrite w)
 {
 	Write = (BusWrite)w;
 	Read = (BusRead)r;
+    Cycle = (ClockCycle)c;
 
 	static bool initialized = false;
 	if (initialized) return;
@@ -943,6 +944,11 @@ void mos6502::Run(
 		cyclesRemaining -=
 			cycleMethod == CYCLE_COUNT        ? instr.cycles
 			/* cycleMethod == INST_COUNT */   : 1;
+
+        // run clock cycle callback
+        if (Cycle)
+            for(int i = 0; i < instr.cycles; i++)
+                Cycle(this);
 	}
 }
 
@@ -961,6 +967,11 @@ void mos6502::RunEternally()
 
 		// execute
 		Exec(instr);
+
+        // run clock cycle callback
+        if (Cycle)
+            for(int i = 0; i < instr.cycles; i++)
+                Cycle(this);
 	}
 }
 

--- a/mos6502.h
+++ b/mos6502.h
@@ -142,11 +142,13 @@ private:
 	static const uint16_t nmiVectorH = 0xFFFB;
 	static const uint16_t nmiVectorL = 0xFFFA;
 
-	// read/write callbacks
+	// read/write/clock-cycle callbacks
 	typedef void (*BusWrite)(uint16_t, uint8_t);
 	typedef uint8_t (*BusRead)(uint16_t);
+    typedef void (*ClockCycle)(mos6502*);
 	BusRead Read;
 	BusWrite Write;
+    ClockCycle Cycle;
 
 	// stack operations
 	inline void StackPush(uint8_t byte);
@@ -157,7 +159,7 @@ public:
 		INST_COUNT,
 		CYCLE_COUNT,
 	};
-	mos6502(BusRead r, BusWrite w);
+	mos6502(BusRead r, BusWrite w, ClockCycle c = nullptr);
 	void NMI();
 	void IRQ();
 	void Reset();


### PR DESCRIPTION
This adds a `ClockCycle` callback function so you can trigger code every time the processor experiences a clock pulse.

```cpp
mos6502 cpu(BusRead, BusWrite, ClockCycle); // You can add it in the 3rd parameter of the constructor.

mos6502 cpu2(BusRead, BusWrite); // You do not have to include it if you don't need it.
```
A `ClockCycle` callback looks like this:
```cpp
void clockCycle(mos6502* cpu)
{
   // 'cpu' is the instance of the 6502 that is being ran.
   // Code goes here.
   gpio.cycle();
   if (gpio.shouldInterrupt())
     cpu->IRQ();
}
```

### What can it be used for?
I am developing a virtual microcontroller that uses the `mos6502` as a core. This system has modules such a GPIO, Timers, and Serial Interfaces that the processor can interact with. Everything in the MCU is running on the same clock as the CPU.

Each module needs to be updated on each clock cycle so that it can trigger interrupts at the correct time. This callback allows that by being invoked however many cycles that 6502 runs at.

```cpp
cpu.Run(100, cyclesCounter); // Invokes 'ClockCycle' callback ~100 times
```

**Note:** The method of counting cycles for this callback is always `CYCLE_COUNT`. The idea is that modules are relying on a system clock, and `INST_COUNT` wouldn't make sense because the modules in the real world won't necessarily know how many instructions the 6502 has executed.

### Inner Main Loop Changes
```cpp
while(start + n > cycles && !illegalOpcode)
{
	// fetch
	opcode = Read(pc++);

	// decode
	instr = InstrTable[opcode];

	// execute
	Exec(instr);
        
        // ---- new code added here ---- //
        // run clock cycle callback
        if (Cycle)
                for(int i = 0; i < instr.cycles; i++)
                        Cycle(this);
}
```