### PR TITLE
accurate cycle times, even for page boundary crossing

### DIFF
--- a/mos6502.cpp
+++ b/mos6502.cpp
@@ -30,1596 +30,1166 @@
 mos6502::Instr mos6502::InstrTable[256];
 
 mos6502::mos6502(BusRead r, BusWrite w, ClockCycle c)
-	: reset_A(0x00)
-    , reset_X(0x00)
-    , reset_Y(0x00)
-    , reset_sp(0xFD)
-    , reset_status(CONSTANT)
+   : reset_A(0x00)
+   , reset_X(0x00)
+   , reset_Y(0x00)
+   , reset_sp(0xFD)
+   , reset_status(CONSTANT)
 {
-	Write = (BusWrite)w;
-	Read = (BusRead)r;
-	Cycle = (ClockCycle)c;
+   Write = (BusWrite)w;
+   Read = (BusRead)r;
+   Cycle = (ClockCycle)c;
 
-	static bool initialized = false;
-	if (initialized) return;
-	initialized = true;
+   static bool initialized = false;
+   if (initialized) return;
+   initialized = true;
 
-	Instr instr;
-	// fill jump table with ILLEGALs
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_ILLEGAL;
-	for(int i = 0; i < 256; i++)
-	{
-		InstrTable[i] = instr;
-	}
+   Instr instr;
+   // fill jump table with ILLEGALs
+   instr.addr = &mos6502::Addr_IMP;
+   instr.saddr = "(null)";
+   instr.code = &mos6502::Op_ILLEGAL;
+   instr.scode = "(null)";
+   instr.penalty = false;
+   for(int i = 0; i < 256; i++)
+   {
+      InstrTable[i] = instr;
+   }
 
-	// insert opcodes
+   // insert opcodes
+#define MAKE_INSTR(HEX, CODE, MODE, CYCLES, PENALTY) \
+   instr.code = &mos6502::Op_ ## CODE; \
+   instr.scode = # CODE; \
+   instr.addr = &mos6502::Addr_ ## MODE; \
+   instr.saddr = # MODE; \
+   instr.cycles = CYCLES; \
+   instr.penalty = PENALTY; \
+   InstrTable[HEX] = instr;
 
-	instr.addr = &mos6502::Addr_IMM;
-	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 2;
-	InstrTable[0x69] = instr;
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 4;
-	InstrTable[0x6D] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 3;
-	InstrTable[0x65] = instr;
-	instr.addr = &mos6502::Addr_INX;
-	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 6;
-	InstrTable[0x61] = instr;
-	instr.addr = &mos6502::Addr_INY;
-	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 6;
-	InstrTable[0x71] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 4;
-	InstrTable[0x75] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 4;
-	InstrTable[0x7D] = instr;
-	instr.addr = &mos6502::Addr_ABY;
-	instr.code = &mos6502::Op_ADC;
-	instr.cycles = 4;
-	InstrTable[0x79] = instr;
+   MAKE_INSTR(0x69, ADC, IMM, 2, false);
+   MAKE_INSTR(0x6D, ADC, ABS, 4, false);
+   MAKE_INSTR(0x65, ADC, ZER, 3, false);
+   MAKE_INSTR(0x61, ADC, INX, 6, false);
+   MAKE_INSTR(0x71, ADC, INY, 5, true);
+   MAKE_INSTR(0x75, ADC, ZEX, 4, false);
+   MAKE_INSTR(0x7D, ADC, ABX, 4, true);
+   MAKE_INSTR(0x79, ADC, ABY, 4, true);
 
-	instr.addr = &mos6502::Addr_IMM;
-	instr.code = &mos6502::Op_AND;
-	instr.cycles = 2;
-	InstrTable[0x29] = instr;
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_AND;
-	instr.cycles = 4;
-	InstrTable[0x2D] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_AND;
-	instr.cycles = 3;
-	InstrTable[0x25] = instr;
-	instr.addr = &mos6502::Addr_INX;
-	instr.code = &mos6502::Op_AND;
-	instr.cycles = 6;
-	InstrTable[0x21] = instr;
-	instr.addr = &mos6502::Addr_INY;
-	instr.code = &mos6502::Op_AND;
-	instr.cycles = 5;
-	InstrTable[0x31] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_AND;
-	instr.cycles = 4;
-	InstrTable[0x35] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_AND;
-	instr.cycles = 4;
-	InstrTable[0x3D] = instr;
-	instr.addr = &mos6502::Addr_ABY;
-	instr.code = &mos6502::Op_AND;
-	instr.cycles = 4;
-	InstrTable[0x39] = instr;
+   MAKE_INSTR(0x29, AND, IMM, 2, false);
+   MAKE_INSTR(0x2D, AND, ABS, 4, false);
+   MAKE_INSTR(0x25, AND, ZER, 3, false);
+   MAKE_INSTR(0x21, AND, INX, 6, false);
+   MAKE_INSTR(0x31, AND, INY, 5, true);
+   MAKE_INSTR(0x35, AND, ZEX, 4, false);
+   MAKE_INSTR(0x3D, AND, ABX, 4, true);
+   MAKE_INSTR(0x39, AND, ABY, 4, true);
 
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_ASL;
-	instr.cycles = 6;
-	InstrTable[0x0E] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_ASL;
-	instr.cycles = 5;
-	InstrTable[0x06] = instr;
-	instr.addr = &mos6502::Addr_ACC;
-	instr.code = &mos6502::Op_ASL_ACC;
-	instr.cycles = 2;
-	InstrTable[0x0A] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_ASL;
-	instr.cycles = 6;
-	InstrTable[0x16] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_ASL;
-	instr.cycles = 7;
-	InstrTable[0x1E] = instr;
+   MAKE_INSTR(0x0E, ASL, ABS, 6, false);
+   MAKE_INSTR(0x06, ASL, ZER, 5, false);
+   MAKE_INSTR(0x0A, ASL_ACC, ACC, 2, false);
+   MAKE_INSTR(0x16, ASL, ZEX, 6, false);
+   MAKE_INSTR(0x1E, ASL, ABX, 7, false);
 
-	instr.addr = &mos6502::Addr_REL;
-	instr.code = &mos6502::Op_BCC;
-	instr.cycles = 2;
-	InstrTable[0x90] = instr;
+   MAKE_INSTR(0x90, BCC, REL, 2, true);
+   MAKE_INSTR(0xB0, BCS, REL, 2, true);
+   MAKE_INSTR(0xF0, BEQ, REL, 2, true);
 
-	instr.addr = &mos6502::Addr_REL;
-	instr.code = &mos6502::Op_BCS;
-	instr.cycles = 2;
-	InstrTable[0xB0] = instr;
+   MAKE_INSTR(0x2C, BIT, ABS, 4, false);
+   MAKE_INSTR(0x24, BIT, ZER, 3, false);
 
-	instr.addr = &mos6502::Addr_REL;
-	instr.code = &mos6502::Op_BEQ;
-	instr.cycles = 2;
-	InstrTable[0xF0] = instr;
+   MAKE_INSTR(0x30, BMI, REL, 2, true);
+   MAKE_INSTR(0xD0, BNE, REL, 2, true);
+   MAKE_INSTR(0x10, BPL, REL, 2, true);
 
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_BIT;
-	instr.cycles = 4;
-	InstrTable[0x2C] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_BIT;
-	instr.cycles = 3;
-	InstrTable[0x24] = instr;
+   MAKE_INSTR(0x00, BRK, IMP, 7, false);
 
-	instr.addr = &mos6502::Addr_REL;
-	instr.code = &mos6502::Op_BMI;
-	instr.cycles = 2;
-	InstrTable[0x30] = instr;
+   MAKE_INSTR(0x50, BVC, REL, 2, true);
+   MAKE_INSTR(0x70, BVS, REL, 2, true);
 
-	instr.addr = &mos6502::Addr_REL;
-	instr.code = &mos6502::Op_BNE;
-	instr.cycles = 2;
-	InstrTable[0xD0] = instr;
+   MAKE_INSTR(0x18, CLC, IMP, 2, false);
+   MAKE_INSTR(0xD8, CLD, IMP, 2, false);
+   MAKE_INSTR(0x58, CLI, IMP, 2, false);
+   MAKE_INSTR(0xB8, CLV, IMP, 2, false);
 
-	instr.addr = &mos6502::Addr_REL;
-	instr.code = &mos6502::Op_BPL;
-	instr.cycles = 2;
-	InstrTable[0x10] = instr;
+   MAKE_INSTR(0xC9, CMP, IMM, 2, false);
+   MAKE_INSTR(0xCD, CMP, ABS, 4, false);
+   MAKE_INSTR(0xC5, CMP, ZER, 3, false);
+   MAKE_INSTR(0xC1, CMP, INX, 6, false);
+   MAKE_INSTR(0xD1, CMP, INY, 5, true);
+   MAKE_INSTR(0xD5, CMP, ZEX, 4, false);
+   MAKE_INSTR(0xDD, CMP, ABX, 4, true);
+   MAKE_INSTR(0xD9, CMP, ABY, 4, true);
 
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_BRK;
-	instr.cycles = 7;
-	InstrTable[0x00] = instr;
+   MAKE_INSTR(0xE0, CPX, IMM, 2, false);
+   MAKE_INSTR(0xEC, CPX, ABS, 4, false);
+   MAKE_INSTR(0xE4, CPX, ZER, 3, false);
 
-	instr.addr = &mos6502::Addr_REL;
-	instr.code = &mos6502::Op_BVC;
-	instr.cycles = 2;
-	InstrTable[0x50] = instr;
+   MAKE_INSTR(0xC0, CPY, IMM, 2, false);
+   MAKE_INSTR(0xCC, CPY, ABS, 4, false);
+   MAKE_INSTR(0xC4, CPY, ZER, 3, false);
 
-	instr.addr = &mos6502::Addr_REL;
-	instr.code = &mos6502::Op_BVS;
-	instr.cycles = 2;
-	InstrTable[0x70] = instr;
+   MAKE_INSTR(0xCE, DEC, ABS, 6, false);
+   MAKE_INSTR(0xC6, DEC, ZER, 5, false);
+   MAKE_INSTR(0xD6, DEC, ZEX, 6, false);
+   MAKE_INSTR(0xDE, DEC, ABX, 7, false);
 
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_CLC;
-	instr.cycles = 2;
-	InstrTable[0x18] = instr;
+   MAKE_INSTR(0xCA, DEX, IMP, 2, false);
+   MAKE_INSTR(0x88, DEY, IMP, 2, false);
 
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_CLD;
-	instr.cycles = 2;
-	InstrTable[0xD8] = instr;
+   MAKE_INSTR(0x49, EOR, IMM, 2, false);
+   MAKE_INSTR(0x4D, EOR, ABS, 4, false);
+   MAKE_INSTR(0x45, EOR, ZER, 3, false);
+   MAKE_INSTR(0x41, EOR, INX, 6, false);
+   MAKE_INSTR(0x51, EOR, INY, 5, true);
+   MAKE_INSTR(0x55, EOR, ZEX, 4, false);
+   MAKE_INSTR(0x5D, EOR, ABX, 4, true);
+   MAKE_INSTR(0x59, EOR, ABY, 4, true);
 
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_CLI;
-	instr.cycles = 2;
-	InstrTable[0x58] = instr;
+   MAKE_INSTR(0xEE, INC, ABS, 6, false);
+   MAKE_INSTR(0xE6, INC, ZER, 5, false);
+   MAKE_INSTR(0xF6, INC, ZEX, 6, false);
+   MAKE_INSTR(0xFE, INC, ABX, 7, false);
 
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_CLV;
-	instr.cycles = 2;
-	InstrTable[0xB8] = instr;
+   MAKE_INSTR(0xE8, INX, IMP, 2, false);
+   MAKE_INSTR(0xC8, INY, IMP, 2, false);
 
-	instr.addr = &mos6502::Addr_IMM;
-	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 2;
-	InstrTable[0xC9] = instr;
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 4;
-	InstrTable[0xCD] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 3;
-	InstrTable[0xC5] = instr;
-	instr.addr = &mos6502::Addr_INX;
-	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 6;
-	InstrTable[0xC1] = instr;
-	instr.addr = &mos6502::Addr_INY;
-	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 3;
-	InstrTable[0xD1] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 4;
-	InstrTable[0xD5] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 4;
-	InstrTable[0xDD] = instr;
-	instr.addr = &mos6502::Addr_ABY;
-	instr.code = &mos6502::Op_CMP;
-	instr.cycles = 4;
-	InstrTable[0xD9] = instr;
+   MAKE_INSTR(0x4C, JMP, ABS, 3, false);
+   MAKE_INSTR(0x6C, JMP, ABI, 5, false);
 
-	instr.addr = &mos6502::Addr_IMM;
-	instr.code = &mos6502::Op_CPX;
-	instr.cycles = 2;
-	InstrTable[0xE0] = instr;
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_CPX;
-	instr.cycles = 4;
-	InstrTable[0xEC] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_CPX;
-	instr.cycles = 3;
-	InstrTable[0xE4] = instr;
+   MAKE_INSTR(0x20, JSR, ABS, 6, false);
 
-	instr.addr = &mos6502::Addr_IMM;
-	instr.code = &mos6502::Op_CPY;
-	instr.cycles = 2;
-	InstrTable[0xC0] = instr;
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_CPY;
-	instr.cycles = 4;
-	InstrTable[0xCC] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_CPY;
-	instr.cycles = 3;
-	InstrTable[0xC4] = instr;
+   MAKE_INSTR(0xA9, LDA, IMM, 2, false);
+   MAKE_INSTR(0xAD, LDA, ABS, 4, false);
+   MAKE_INSTR(0xA5, LDA, ZER, 3, false);
+   MAKE_INSTR(0xA1, LDA, INX, 6, false);
+   MAKE_INSTR(0xB1, LDA, INY, 5, true);
+   MAKE_INSTR(0xB5, LDA, ZEX, 4, false);
+   MAKE_INSTR(0xBD, LDA, ABX, 4, true);
+   MAKE_INSTR(0xB9, LDA, ABY, 4, true);
 
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_DEC;
-	instr.cycles = 6;
-	InstrTable[0xCE] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_DEC;
-	instr.cycles = 5;
-	InstrTable[0xC6] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_DEC;
-	instr.cycles = 6;
-	InstrTable[0xD6] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_DEC;
-	instr.cycles = 7;
-	InstrTable[0xDE] = instr;
+   MAKE_INSTR(0xA2, LDX, IMM, 2, false);
+   MAKE_INSTR(0xAE, LDX, ABS, 4, false);
+   MAKE_INSTR(0xA6, LDX, ZER, 3, false);
+   MAKE_INSTR(0xBE, LDX, ABY, 4, true);
+   MAKE_INSTR(0xB6, LDX, ZEY, 4, false);
 
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_DEX;
-	instr.cycles = 2;
-	InstrTable[0xCA] = instr;
+   MAKE_INSTR(0xA0, LDY, IMM, 2, false);
+   MAKE_INSTR(0xAC, LDY, ABS, 4, false);
+   MAKE_INSTR(0xA4, LDY, ZER, 3, false);
+   MAKE_INSTR(0xB4, LDY, ZEX, 4, false);
+   MAKE_INSTR(0xBC, LDY, ABX, 4, true);
 
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_DEY;
-	instr.cycles = 2;
-	InstrTable[0x88] = instr;
+   MAKE_INSTR(0x4E, LSR, ABS, 6, false);
+   MAKE_INSTR(0x46, LSR, ZER, 5, false);
+   MAKE_INSTR(0x4A, LSR_ACC, ACC, 2, false);
+   MAKE_INSTR(0x56, LSR, ZEX, 6, false);
+   MAKE_INSTR(0x5E, LSR, ABX, 7, false);
 
-	instr.addr = &mos6502::Addr_IMM;
-	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 2;
-	InstrTable[0x49] = instr;
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 4;
-	InstrTable[0x4D] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 3;
-	InstrTable[0x45] = instr;
-	instr.addr = &mos6502::Addr_INX;
-	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 6;
-	InstrTable[0x41] = instr;
-	instr.addr = &mos6502::Addr_INY;
-	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 5;
-	InstrTable[0x51] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 4;
-	InstrTable[0x55] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 4;
-	InstrTable[0x5D] = instr;
-	instr.addr = &mos6502::Addr_ABY;
-	instr.code = &mos6502::Op_EOR;
-	instr.cycles = 4;
-	InstrTable[0x59] = instr;
+   MAKE_INSTR(0xEA, NOP, IMP, 2, false);
 
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_INC;
-	instr.cycles = 6;
-	InstrTable[0xEE] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_INC;
-	instr.cycles = 5;
-	InstrTable[0xE6] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_INC;
-	instr.cycles = 6;
-	InstrTable[0xF6] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_INC;
-	instr.cycles = 7;
-	InstrTable[0xFE] = instr;
+   MAKE_INSTR(0x09, ORA, IMM, 2, false);
+   MAKE_INSTR(0x0D, ORA, ABS, 4, false);
+   MAKE_INSTR(0x05, ORA, ZER, 3, false);
+   MAKE_INSTR(0x01, ORA, INX, 6, false);
+   MAKE_INSTR(0x11, ORA, INY, 5, true);
+   MAKE_INSTR(0x15, ORA, ZEX, 4, false);
+   MAKE_INSTR(0x1D, ORA, ABX, 4, true);
+   MAKE_INSTR(0x19, ORA, ABY, 4, true);
 
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_INX;
-	instr.cycles = 2;
-	InstrTable[0xE8] = instr;
+   MAKE_INSTR(0x48, PHA, IMP, 3, false);
+   MAKE_INSTR(0x08, PHP, IMP, 3, false);
+   MAKE_INSTR(0x68, PLA, IMP, 4, false);
+   MAKE_INSTR(0x28, PLP, IMP, 4, false);
 
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_INY;
-	instr.cycles = 2;
-	InstrTable[0xC8] = instr;
+   MAKE_INSTR(0x2E, ROL, ABS, 6, false);
+   MAKE_INSTR(0x26, ROL, ZER, 5, false);
+   MAKE_INSTR(0x2A, ROL_ACC, ACC, 2, false);
+   MAKE_INSTR(0x36, ROL, ZEX, 6, false);
+   MAKE_INSTR(0x3E, ROL, ABX, 7, false);
 
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_JMP;
-	instr.cycles = 3;
-	InstrTable[0x4C] = instr;
-	instr.addr = &mos6502::Addr_ABI;
-	instr.code = &mos6502::Op_JMP;
-	instr.cycles = 5;
-	InstrTable[0x6C] = instr;
+   MAKE_INSTR(0x6E, ROR, ABS, 6, false);
+   MAKE_INSTR(0x66, ROR, ZER, 5, false);
+   MAKE_INSTR(0x6A, ROR_ACC, ACC, 2, false);
+   MAKE_INSTR(0x76, ROR, ZEX, 6, false);
+   MAKE_INSTR(0x7E, ROR, ABX, 7, false);
 
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_JSR;
-	instr.cycles = 6;
-	InstrTable[0x20] = instr;
+   MAKE_INSTR(0x40, RTI, IMP, 6, false);
+   MAKE_INSTR(0x60, RTS, IMP, 6, false);
 
-	instr.addr = &mos6502::Addr_IMM;
-	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 2;
-	InstrTable[0xA9] = instr;
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 4;
-	InstrTable[0xAD] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 3;
-	InstrTable[0xA5] = instr;
-	instr.addr = &mos6502::Addr_INX;
-	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 6;
-	InstrTable[0xA1] = instr;
-	instr.addr = &mos6502::Addr_INY;
-	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 5;
-	InstrTable[0xB1] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 4;
-	InstrTable[0xB5] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 4;
-	InstrTable[0xBD] = instr;
-	instr.addr = &mos6502::Addr_ABY;
-	instr.code = &mos6502::Op_LDA;
-	instr.cycles = 4;
-	InstrTable[0xB9] = instr;
+   MAKE_INSTR(0xE9, SBC, IMM, 2, false);
+   MAKE_INSTR(0xED, SBC, ABS, 4, false);
+   MAKE_INSTR(0xE5, SBC, ZER, 3, false);
+   MAKE_INSTR(0xE1, SBC, INX, 6, false);
+   MAKE_INSTR(0xF1, SBC, INY, 5, true);
+   MAKE_INSTR(0xF5, SBC, ZEX, 4, false);
+   MAKE_INSTR(0xFD, SBC, ABX, 4, true);
+   MAKE_INSTR(0xF9, SBC, ABY, 4, true);
 
-	instr.addr = &mos6502::Addr_IMM;
-	instr.code = &mos6502::Op_LDX;
-	instr.cycles = 2;
-	InstrTable[0xA2] = instr;
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_LDX;
-	instr.cycles = 4;
-	InstrTable[0xAE] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_LDX;
-	instr.cycles = 3;
-	InstrTable[0xA6] = instr;
-	instr.addr = &mos6502::Addr_ABY;
-	instr.code = &mos6502::Op_LDX;
-	instr.cycles = 4;
-	InstrTable[0xBE] = instr;
-	instr.addr = &mos6502::Addr_ZEY;
-	instr.code = &mos6502::Op_LDX;
-	instr.cycles = 4;
-	InstrTable[0xB6] = instr;
+   MAKE_INSTR(0x38, SEC, IMP, 2, false);
+   MAKE_INSTR(0xF8, SED, IMP, 2, false);
+   MAKE_INSTR(0x78, SEI, IMP, 2, false);
 
-	instr.addr = &mos6502::Addr_IMM;
-	instr.code = &mos6502::Op_LDY;
-	instr.cycles = 2;
-	InstrTable[0xA0] = instr;
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_LDY;
-	instr.cycles = 4;
-	InstrTable[0xAC] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_LDY;
-	instr.cycles = 3;
-	InstrTable[0xA4] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_LDY;
-	instr.cycles = 4;
-	InstrTable[0xB4] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_LDY;
-	instr.cycles = 4;
-	InstrTable[0xBC] = instr;
+   MAKE_INSTR(0x8D, STA, ABS, 4, false);
+   MAKE_INSTR(0x85, STA, ZER, 3, false);
+   MAKE_INSTR(0x81, STA, INX, 6, false);
+   MAKE_INSTR(0x91, STA, INY, 6, false);
+   MAKE_INSTR(0x95, STA, ZEX, 4, false);
+   MAKE_INSTR(0x9D, STA, ABX, 5, false);
+   MAKE_INSTR(0x99, STA, ABY, 5, false);
 
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_LSR;
-	instr.cycles = 6;
-	InstrTable[0x4E] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_LSR;
-	instr.cycles = 5;
-	InstrTable[0x46] = instr;
-	instr.addr = &mos6502::Addr_ACC;
-	instr.code = &mos6502::Op_LSR_ACC;
-	instr.cycles = 2;
-	InstrTable[0x4A] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_LSR;
-	instr.cycles = 6;
-	InstrTable[0x56] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_LSR;
-	instr.cycles = 7;
-	InstrTable[0x5E] = instr;
+   MAKE_INSTR(0x8E, STX, ABS, 4, false);
+   MAKE_INSTR(0x86, STX, ZER, 3, false);
+   MAKE_INSTR(0x96, STX, ZEY, 4, false);
 
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_NOP;
-	instr.cycles = 2;
-	InstrTable[0xEA] = instr;
+   MAKE_INSTR(0x8C, STY, ABS, 4, false);
+   MAKE_INSTR(0x84, STY, ZER, 3, false);
+   MAKE_INSTR(0x94, STY, ZEX, 4, false);
 
-	instr.addr = &mos6502::Addr_IMM;
-	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 2;
-	InstrTable[0x09] = instr;
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 4;
-	InstrTable[0x0D] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 3;
-	InstrTable[0x05] = instr;
-	instr.addr = &mos6502::Addr_INX;
-	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 6;
-	InstrTable[0x01] = instr;
-	instr.addr = &mos6502::Addr_INY;
-	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 5;
-	InstrTable[0x11] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 4;
-	InstrTable[0x15] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 4;
-	InstrTable[0x1D] = instr;
-	instr.addr = &mos6502::Addr_ABY;
-	instr.code = &mos6502::Op_ORA;
-	instr.cycles = 4;
-	InstrTable[0x19] = instr;
+   MAKE_INSTR(0xAA, TAX, IMP, 2, false);
+   MAKE_INSTR(0xA8, TAY, IMP, 2, false);
+   MAKE_INSTR(0xBA, TSX, IMP, 2, false);
+   MAKE_INSTR(0x8A, TXA, IMP, 2, false);
+   MAKE_INSTR(0x9A, TXS, IMP, 2, false);
+   MAKE_INSTR(0x98, TYA, IMP, 2, false);
 
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_PHA;
-	instr.cycles = 3;
-	InstrTable[0x48] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_PHP;
-	instr.cycles = 3;
-	InstrTable[0x08] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_PLA;
-	instr.cycles = 4;
-	InstrTable[0x68] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_PLP;
-	instr.cycles = 4;
-	InstrTable[0x28] = instr;
-
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_ROL;
-	instr.cycles = 6;
-	InstrTable[0x2E] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_ROL;
-	instr.cycles = 5;
-	InstrTable[0x26] = instr;
-	instr.addr = &mos6502::Addr_ACC;
-	instr.code = &mos6502::Op_ROL_ACC;
-	instr.cycles = 2;
-	InstrTable[0x2A] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_ROL;
-	instr.cycles = 6;
-	InstrTable[0x36] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_ROL;
-	instr.cycles = 7;
-	InstrTable[0x3E] = instr;
-
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_ROR;
-	instr.cycles = 6;
-	InstrTable[0x6E] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_ROR;
-	instr.cycles = 5;
-	InstrTable[0x66] = instr;
-	instr.addr = &mos6502::Addr_ACC;
-	instr.code = &mos6502::Op_ROR_ACC;
-	instr.cycles = 2;
-	InstrTable[0x6A] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_ROR;
-	instr.cycles = 6;
-	InstrTable[0x76] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_ROR;
-	instr.cycles = 7;
-	InstrTable[0x7E] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_RTI;
-	instr.cycles = 6;
-	InstrTable[0x40] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_RTS;
-	instr.cycles = 6;
-	InstrTable[0x60] = instr;
-
-	instr.addr = &mos6502::Addr_IMM;
-	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 2;
-	InstrTable[0xE9] = instr;
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 4;
-	InstrTable[0xED] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 3;
-	InstrTable[0xE5] = instr;
-	instr.addr = &mos6502::Addr_INX;
-	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 6;
-	InstrTable[0xE1] = instr;
-	instr.addr = &mos6502::Addr_INY;
-	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 5;
-	InstrTable[0xF1] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 4;
-	InstrTable[0xF5] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 4;
-	InstrTable[0xFD] = instr;
-	instr.addr = &mos6502::Addr_ABY;
-	instr.code = &mos6502::Op_SBC;
-	instr.cycles = 4;
-	InstrTable[0xF9] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_SEC;
-	instr.cycles = 2;
-	InstrTable[0x38] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_SED;
-	instr.cycles = 2;
-	InstrTable[0xF8] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_SEI;
-	instr.cycles = 2;
-	InstrTable[0x78] = instr;
-
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_STA;
-	instr.cycles = 4;
-	InstrTable[0x8D] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_STA;
-	instr.cycles = 3;
-	InstrTable[0x85] = instr;
-	instr.addr = &mos6502::Addr_INX;
-	instr.code = &mos6502::Op_STA;
-	instr.cycles = 6;
-	InstrTable[0x81] = instr;
-	instr.addr = &mos6502::Addr_INY;
-	instr.code = &mos6502::Op_STA;
-	instr.cycles = 6;
-	InstrTable[0x91] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_STA;
-	instr.cycles = 4;
-	InstrTable[0x95] = instr;
-	instr.addr = &mos6502::Addr_ABX;
-	instr.code = &mos6502::Op_STA;
-	instr.cycles = 5;
-	InstrTable[0x9D] = instr;
-	instr.addr = &mos6502::Addr_ABY;
-	instr.code = &mos6502::Op_STA;
-	instr.cycles = 5;
-	InstrTable[0x99] = instr;
-
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_STX;
-	instr.cycles = 4;
-	InstrTable[0x8E] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_STX;
-	instr.cycles = 3;
-	InstrTable[0x86] = instr;
-	instr.addr = &mos6502::Addr_ZEY;
-	instr.code = &mos6502::Op_STX;
-	instr.cycles = 4;
-	InstrTable[0x96] = instr;
-
-	instr.addr = &mos6502::Addr_ABS;
-	instr.code = &mos6502::Op_STY;
-	instr.cycles = 4;
-	InstrTable[0x8C] = instr;
-	instr.addr = &mos6502::Addr_ZER;
-	instr.code = &mos6502::Op_STY;
-	instr.cycles = 3;
-	InstrTable[0x84] = instr;
-	instr.addr = &mos6502::Addr_ZEX;
-	instr.code = &mos6502::Op_STY;
-	instr.cycles = 4;
-	InstrTable[0x94] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_TAX;
-	instr.cycles = 2;
-	InstrTable[0xAA] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_TAY;
-	instr.cycles = 2;
-	InstrTable[0xA8] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_TSX;
-	instr.cycles = 2;
-	InstrTable[0xBA] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_TXA;
-	instr.cycles = 2;
-	InstrTable[0x8A] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_TXS;
-	instr.cycles = 2;
-	InstrTable[0x9A] = instr;
-
-	instr.addr = &mos6502::Addr_IMP;
-	instr.code = &mos6502::Op_TYA;
-	instr.cycles = 2;
-	InstrTable[0x98] = instr;
-
-	return;
+   return;
 }
 
 uint16_t mos6502::Addr_ACC()
 {
-	return 0; // not used
+   return 0; // not used
 }
 
 uint16_t mos6502::Addr_IMM()
 {
-	return pc++;
+   return pc++;
 }
 
 uint16_t mos6502::Addr_ABS()
 {
-	uint16_t addrL;
-	uint16_t addrH;
-	uint16_t addr;
+   uint16_t addrL;
+   uint16_t addrH;
+   uint16_t addr;
 
-	addrL = Read(pc++);
-	addrH = Read(pc++);
+   addrL = Read(pc++);
+   addrH = Read(pc++);
 
-	addr = addrL + (addrH << 8);
+   addr = addrL + (addrH << 8);
 
-	return addr;
+   return addr;
 }
 
 uint16_t mos6502::Addr_ZER()
 {
-	return Read(pc++);
+   return Read(pc++);
 }
 
 uint16_t mos6502::Addr_IMP()
 {
-	return 0; // not used
+   return 0; // not used
 }
 
 uint16_t mos6502::Addr_REL()
 {
-	uint16_t offset;
-	uint16_t addr;
+   uint16_t offset;
+   uint16_t addr;
 
-	offset = (uint16_t)Read(pc++);
-	if (offset & 0x80) offset |= 0xFF00;
-	addr = pc + (int16_t)offset;
-	return addr;
+   offset = (uint16_t)Read(pc++);
+   if (offset & 0x80) offset |= 0xFF00;
+   addr = pc + (int16_t)offset;
+   crossed = (addr & 0xFF00) != (pc & 0xFF00);
+
+   return addr;
 }
 
 uint16_t mos6502::Addr_ABI()
 {
-	uint16_t addrL;
-	uint16_t addrH;
-	uint16_t effL;
-	uint16_t effH;
-	uint16_t abs;
-	uint16_t addr;
+   uint16_t addrL;
+   uint16_t addrH;
+   uint16_t effL;
+   uint16_t effH;
+   uint16_t abs;
+   uint16_t addr;
 
-	addrL = Read(pc++);
-	addrH = Read(pc++);
+   addrL = Read(pc++);
+   addrH = Read(pc++);
 
-	abs = (addrH << 8) | addrL;
+   abs = (addrH << 8) | addrL;
 
-	effL = Read(abs);
+   effL = Read(abs);
 
 #ifndef CMOS_INDIRECT_JMP_FIX
-	effH = Read((abs & 0xFF00) + ((abs + 1) & 0x00FF) );
+   effH = Read((abs & 0xFF00) + ((abs + 1) & 0x00FF) );
 #else
-	effH = Read(abs + 1);
+   effH = Read(abs + 1);
 #endif
 
-	addr = effL + 0x100 * effH;
+   addr = effL + 0x100 * effH;
 
-	return addr;
+   return addr;
 }
 
 uint16_t mos6502::Addr_ZEX()
 {
-	uint16_t addr = (Read(pc++) + X) & 0xFF;
-	return addr;
+   uint16_t addr = (Read(pc++) + X) & 0xFF;
+   return addr;
 }
 
 uint16_t mos6502::Addr_ZEY()
 {
-	uint16_t addr = (Read(pc++) + Y) & 0xFF;
-	return addr;
+   uint16_t addr = (Read(pc++) + Y) & 0xFF;
+   return addr;
 }
 
 uint16_t mos6502::Addr_ABX()
 {
-	uint16_t addr;
-	uint16_t addrL;
-	uint16_t addrH;
+   uint16_t addr;
+   uint16_t addrL;
+   uint16_t addrH;
 
-	addrL = Read(pc++);
-	addrH = Read(pc++);
+   addrL = Read(pc++);
+   addrH = Read(pc++);
 
-	addr = addrL + (addrH << 8) + X;
-	return addr;
+   addr = addrL + (addrH << 8) + X;
+   crossed = (addrL + X) > 255;
+   return addr;
 }
 
 uint16_t mos6502::Addr_ABY()
 {
-	uint16_t addr;
-	uint16_t addrL;
-	uint16_t addrH;
+   uint16_t addr;
+   uint16_t addrL;
+   uint16_t addrH;
 
-	addrL = Read(pc++);
-	addrH = Read(pc++);
+   addrL = Read(pc++);
+   addrH = Read(pc++);
 
-	addr = addrL + (addrH << 8) + Y;
-	return addr;
+   addr = addrL + (addrH << 8) + Y;
+   crossed = (addrL + Y) > 255;
+   return addr;
 }
-
 
 uint16_t mos6502::Addr_INX()
 {
-	uint16_t zeroL;
-	uint16_t zeroH;
-	uint16_t addr;
+   uint16_t zeroL;
+   uint16_t zeroH;
+   uint16_t addr;
 
-	zeroL = (Read(pc++) + X) & 0xFF;
-	zeroH = (zeroL + 1) & 0xFF;
-	addr = Read(zeroL) + (Read(zeroH) << 8);
+   zeroL = (Read(pc++) + X) & 0xFF;
+   zeroH = (zeroL + 1) & 0xFF;
+   addr = Read(zeroL) + (Read(zeroH) << 8);
 
-	return addr;
+   return addr;
 }
 
 uint16_t mos6502::Addr_INY()
 {
-	uint16_t zeroL;
-	uint16_t zeroH;
-	uint16_t addr;
+   uint16_t baseL;
+   uint16_t zeroL;
+   uint16_t zeroH;
+   uint16_t addr;
 
-	zeroL = Read(pc++);
-	zeroH = (zeroL + 1) & 0xFF;
-	addr = Read(zeroL) + (Read(zeroH) << 8) + Y;
+   zeroL = Read(pc++);
+   zeroH = (zeroL + 1) & 0xFF;
+   addr = (baseL = /* ASSIGN */ Read(zeroL)) + (Read(zeroH) << 8) + Y;
+   crossed = (baseL + Y) > 255;
 
-	return addr;
+   return addr;
 }
 
 void mos6502::Reset()
 {
-	A = reset_A;
-	Y = reset_Y;
-	X = reset_X;
+   A = reset_A;
+   Y = reset_Y;
+   X = reset_X;
 
-	// load PC from reset vector
-	uint8_t pcl = Read(rstVectorL);
-	uint8_t pch = Read(rstVectorH);
-	pc = (pch << 8) + pcl;
+   // load PC from reset vector
+   uint8_t pcl = Read(rstVectorL);
+   uint8_t pch = Read(rstVectorH);
+   pc = (pch << 8) + pcl;
 
-	sp = reset_sp;
+   sp = reset_sp;
 
-	status = reset_status | CONSTANT | BREAK;
+   status = reset_status | CONSTANT | BREAK;
 
-	illegalOpcode = false;
+   illegalOpcode = false;
 
-	return;
+   return;
 }
 
 void mos6502::StackPush(uint8_t byte)
 {
-	Write(0x0100 + sp, byte);
-	if(sp == 0x00) sp = 0xFF;
-	else sp--;
+   Write(0x0100 + sp, byte);
+   if(sp == 0x00) sp = 0xFF;
+   else sp--;
 }
 
 uint8_t mos6502::StackPop()
 {
-	if(sp == 0xFF) sp = 0x00;
-	else sp++;
-	return Read(0x0100 + sp);
+   if(sp == 0xFF) sp = 0x00;
+   else sp++;
+   return Read(0x0100 + sp);
 }
 
 void mos6502::IRQ()
 {
-	if(!IF_INTERRUPT())
-	{
-		//SET_BREAK(0);
-		StackPush((pc >> 8) & 0xFF);
-		StackPush(pc & 0xFF);
-		StackPush((status & ~BREAK) | CONSTANT);
-		SET_INTERRUPT(1);
+   if(!IF_INTERRUPT())
+   {
+      //SET_BREAK(0);
+      StackPush((pc >> 8) & 0xFF);
+      StackPush(pc & 0xFF);
+      StackPush((status & ~BREAK) | CONSTANT);
+      SET_INTERRUPT(1);
 
-		// load PC from interrupt request vector
-		uint8_t pcl = Read(irqVectorL);
-		uint8_t pch = Read(irqVectorH);
-		pc = (pch << 8) + pcl;
-	}
-	return;
+      // load PC from interrupt request vector
+      uint8_t pcl = Read(irqVectorL);
+      uint8_t pch = Read(irqVectorH);
+      pc = (pch << 8) + pcl;
+   }
+   return;
 }
 
 void mos6502::NMI()
 {
-	//SET_BREAK(0);
-	StackPush((pc >> 8) & 0xFF);
-	StackPush(pc & 0xFF);
-	StackPush((status & ~BREAK) | CONSTANT);
-	SET_INTERRUPT(1);
+   //SET_BREAK(0);
+   StackPush((pc >> 8) & 0xFF);
+   StackPush(pc & 0xFF);
+   StackPush((status & ~BREAK) | CONSTANT);
+   SET_INTERRUPT(1);
 
-	// load PC from non-maskable interrupt vector
-	uint8_t pcl = Read(nmiVectorL);
-	uint8_t pch = Read(nmiVectorH);
-	pc = (pch << 8) + pcl;
-	return;
+   // load PC from non-maskable interrupt vector
+   uint8_t pcl = Read(nmiVectorL);
+   uint8_t pch = Read(nmiVectorH);
+   pc = (pch << 8) + pcl;
+   return;
 }
 
 void mos6502::Run(
-	int32_t cyclesRemaining,
-	uint64_t& cycleCount,
-	CycleMethod cycleMethod
-) {
-	uint8_t opcode;
-	Instr instr;
+      int32_t cyclesRemaining,
+      uint64_t& cycleCount,
+      CycleMethod cycleMethod)
+{
+   uint8_t opcode;
+   Instr instr;
 
-	while(cyclesRemaining > 0 && !illegalOpcode)
-	{
-		// fetch
-		opcode = Read(pc++);
+   while(cyclesRemaining > 0 && !illegalOpcode)
+   {
+      // fetch
+      opcode = Read(pc++);
 
-		// decode
-		instr = InstrTable[opcode];
+      // decode
+      instr = InstrTable[opcode];
 
-		// execute
-		Exec(instr);
-		cycleCount += instr.cycles;
-		cyclesRemaining -=
-			cycleMethod == CYCLE_COUNT        ? instr.cycles
-			/* cycleMethod == INST_COUNT */   : 1;
+      // execute
+      Exec(instr);
 
-		// run clock cycle callback
-		if (Cycle)
-			for(int i = 0; i < instr.cycles; i++)
-				Cycle(this);
-	}
+      cycleCount += instr.cycles;
+      if (instr.penalty && crossed) {
+         cycleCount++;
+      }
+      cyclesRemaining -=
+         cycleMethod == CYCLE_COUNT        ? instr.cycles
+         /* cycleMethod == INST_COUNT */   : 1;
+
+      // run clock cycle callback
+      if (Cycle)
+         for(int i = 0; i < instr.cycles; i++)
+            Cycle(this);
+   }
 }
 
 void mos6502::RunEternally()
 {
-	uint8_t opcode;
-	Instr instr;
+   uint8_t opcode;
+   Instr instr;
 
-	while(!illegalOpcode)
-	{
-		// fetch
-		opcode = Read(pc++);
+   while(!illegalOpcode)
+   {
+      // fetch
+      opcode = Read(pc++);
 
-		// decode
-		instr = InstrTable[opcode];
+      // decode
+      instr = InstrTable[opcode];
 
-		// execute
-		Exec(instr);
+      // execute
+      Exec(instr);
 
-		// run clock cycle callback
-		if (Cycle)
-			for(int i = 0; i < instr.cycles; i++)
-				Cycle(this);
-	}
+      // run clock cycle callback
+      if (Cycle)
+         for(int i = 0; i < instr.cycles; i++)
+            Cycle(this);
+   }
 }
 
 void mos6502::Exec(Instr i)
 {
-	uint16_t src = (this->*i.addr)();
-	(this->*i.code)(src);
+   crossed = false;
+   uint16_t src = (this->*i.addr)();
+   (this->*i.code)(src);
 }
 
 uint16_t mos6502::GetPC()
 {
-    return pc;
+   return pc;
 }
 
 uint8_t mos6502::GetS()
 {
-    return sp;
+   return sp;
 }
 
 uint8_t mos6502::GetP()
 {
-    return status;
+   return status;
 }
 
 uint8_t mos6502::GetA()
 {
-    return A;
+   return A;
 }
 
 uint8_t mos6502::GetX()
 {
-    return X;
+   return X;
 }
 
 uint8_t mos6502::GetY()
 {
-    return Y;
+   return Y;
 }
 
 void mos6502::SetResetS(uint8_t value)
 {
-    reset_sp = value;
+   reset_sp = value;
 }
 
 void mos6502::SetResetP(uint8_t value)
 {
-    reset_status = value | CONSTANT | BREAK;
+   reset_status = value | CONSTANT | BREAK;
 }
 
 void mos6502::SetResetA(uint8_t value)
 {
-    reset_A = value;
+   reset_A = value;
 }
 
 void mos6502::SetResetX(uint8_t value)
 {
-    reset_X = value;
+   reset_X = value;
 }
 
 void mos6502::SetResetY(uint8_t value)
 {
-    reset_Y = value;
+   reset_Y = value;
 }
 
 uint8_t mos6502::GetResetS()
 {
-    return reset_sp;
+   return reset_sp;
 }
 
 uint8_t mos6502::GetResetP()
 {
-    return reset_status;
+   return reset_status;
 }
 
 uint8_t mos6502::GetResetA()
 {
-    return reset_A;
+   return reset_A;
 }
 
 uint8_t mos6502::GetResetX()
 {
-    return reset_X;
+   return reset_X;
 }
 
 uint8_t mos6502::GetResetY()
 {
-    return reset_Y;
+   return reset_Y;
 }
 
 void mos6502::Op_ILLEGAL(uint16_t src)
 {
-	illegalOpcode = true;
+   illegalOpcode = true;
 }
 
 
 void mos6502::Op_ADC(uint16_t src)
 {
-	uint8_t m = Read(src);
-	unsigned int tmp = m + A + (IF_CARRY() ? 1 : 0);
-	SET_ZERO(!(tmp & 0xFF));
-	if (IF_DECIMAL())
-	{
-		if (((A & 0xF) + (m & 0xF) + (IF_CARRY() ? 1 : 0)) > 9) tmp += 6;
-		SET_NEGATIVE(tmp & 0x80);
-		SET_OVERFLOW(!((A ^ m) & 0x80) && ((A ^ tmp) & 0x80));
-		if (tmp > 0x99)
-		{
-			tmp += 96;
-		}
-		SET_CARRY(tmp > 0x99);
-	}
-	else
-	{
-		SET_NEGATIVE(tmp & 0x80);
-		SET_OVERFLOW(!((A ^ m) & 0x80) && ((A ^ tmp) & 0x80));
-		SET_CARRY(tmp > 0xFF);
-	}
+   uint8_t m = Read(src);
+   unsigned int tmp = m + A + (IF_CARRY() ? 1 : 0);
+   SET_ZERO(!(tmp & 0xFF));
+   if (IF_DECIMAL())
+   {
+      if (((A & 0xF) + (m & 0xF) + (IF_CARRY() ? 1 : 0)) > 9) tmp += 6;
+      SET_NEGATIVE(tmp & 0x80);
+      SET_OVERFLOW(!((A ^ m) & 0x80) && ((A ^ tmp) & 0x80));
+      if (tmp > 0x99)
+      {
+         tmp += 96;
+      }
+      SET_CARRY(tmp > 0x99);
+   }
+   else
+   {
+      SET_NEGATIVE(tmp & 0x80);
+      SET_OVERFLOW(!((A ^ m) & 0x80) && ((A ^ tmp) & 0x80));
+      SET_CARRY(tmp > 0xFF);
+   }
 
-	A = tmp & 0xFF;
-	return;
+   A = tmp & 0xFF;
+   return;
 }
 
 
 
 void mos6502::Op_AND(uint16_t src)
 {
-	uint8_t m = Read(src);
-	uint8_t res = m & A;
-	SET_NEGATIVE(res & 0x80);
-	SET_ZERO(!res);
-	A = res;
-	return;
+   uint8_t m = Read(src);
+   uint8_t res = m & A;
+   SET_NEGATIVE(res & 0x80);
+   SET_ZERO(!res);
+   A = res;
+   return;
 }
 
 
 void mos6502::Op_ASL(uint16_t src)
 {
-	uint8_t m = Read(src);
-	SET_CARRY(m & 0x80);
-	m <<= 1;
-	m &= 0xFF;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	Write(src, m);
-	return;
+   uint8_t m = Read(src);
+   SET_CARRY(m & 0x80);
+   m <<= 1;
+   m &= 0xFF;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   Write(src, m);
+   return;
 }
 
 void mos6502::Op_ASL_ACC(uint16_t src)
 {
-	uint8_t m = A;
-	SET_CARRY(m & 0x80);
-	m <<= 1;
-	m &= 0xFF;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	A = m;
-	return;
+   uint8_t m = A;
+   SET_CARRY(m & 0x80);
+   m <<= 1;
+   m &= 0xFF;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   A = m;
+   return;
 }
 
 void mos6502::Op_BCC(uint16_t src)
 {
-	if (!IF_CARRY())
-	{
-		pc = src;
-	}
-	return;
+   if (!IF_CARRY())
+   {
+      pc = src;
+   }
+   else {
+      crossed = false; // branch not taken does not suffer penalty
+   }
+   return;
 }
-
 
 void mos6502::Op_BCS(uint16_t src)
 {
-	if (IF_CARRY())
-	{
-		pc = src;
-	}
-	return;
+   if (IF_CARRY())
+   {
+      pc = src;
+   }
+   else {
+      crossed = false; // branch not taken does not suffer penalty
+   }
+   return;
 }
 
 void mos6502::Op_BEQ(uint16_t src)
 {
-	if (IF_ZERO())
-	{
-		pc = src;
-	}
-	return;
+   if (IF_ZERO())
+   {
+      pc = src;
+   }
+   else {
+      crossed = false; // branch not taken does not suffer penalty
+   }
+   return;
 }
 
 void mos6502::Op_BIT(uint16_t src)
 {
-	uint8_t m = Read(src);
-	uint8_t res = m & A;
-	SET_NEGATIVE(res & 0x80);
-	status = (status & 0x3F) | (uint8_t)(m & 0xC0) | CONSTANT | BREAK;
-	SET_ZERO(!res);
-	return;
+   uint8_t m = Read(src);
+   uint8_t res = m & A;
+   SET_NEGATIVE(res & 0x80);
+   status = (status & 0x3F) | (uint8_t)(m & 0xC0) | CONSTANT | BREAK;
+   SET_ZERO(!res);
+   return;
 }
 
 void mos6502::Op_BMI(uint16_t src)
 {
-	if (IF_NEGATIVE())
-	{
-		pc = src;
-	}
-	return;
+   if (IF_NEGATIVE())
+   {
+      pc = src;
+   }
+   else {
+      crossed = false; // branch not taken does not suffer penalty
+   }
+   return;
 }
 
 void mos6502::Op_BNE(uint16_t src)
 {
-	if (!IF_ZERO())
-	{
-		pc = src;
-	}
-	return;
+   if (!IF_ZERO())
+   {
+      pc = src;
+   }
+   else {
+      crossed = false; // branch not taken does not suffer penalty
+   }
+   return;
 }
 
 void mos6502::Op_BPL(uint16_t src)
 {
-	if (!IF_NEGATIVE())
-	{
-		pc = src;
-	}
-	return;
+   if (!IF_NEGATIVE())
+   {
+      pc = src;
+   }
+   else {
+      crossed = false; // branch not taken does not suffer penalty
+   }
+   return;
 }
 
 void mos6502::Op_BRK(uint16_t src)
 {
-	pc++;
-	StackPush((pc >> 8) & 0xFF);
-	StackPush(pc & 0xFF);
-	StackPush(status | CONSTANT | BREAK);
-	SET_INTERRUPT(1);
-	pc = (Read(irqVectorH) << 8) + Read(irqVectorL);
-	return;
+   pc++;
+   StackPush((pc >> 8) & 0xFF);
+   StackPush(pc & 0xFF);
+   StackPush(status | CONSTANT | BREAK);
+   SET_INTERRUPT(1);
+   pc = (Read(irqVectorH) << 8) + Read(irqVectorL);
+   return;
 }
 
 void mos6502::Op_BVC(uint16_t src)
 {
-	if (!IF_OVERFLOW())
-	{
-		pc = src;
-	}
-	return;
+   if (!IF_OVERFLOW())
+   {
+      pc = src;
+   }
+   else {
+      crossed = false; // branch not taken does not suffer penalty
+   }
+   return;
 }
 
 void mos6502::Op_BVS(uint16_t src)
 {
-	if (IF_OVERFLOW())
-	{
-		pc = src;
-	}
-	return;
+   if (IF_OVERFLOW())
+   {
+      pc = src;
+   }
+   else {
+      crossed = false; // branch not taken does not suffer penalty
+   }
+   return;
 }
 
 void mos6502::Op_CLC(uint16_t src)
 {
-	SET_CARRY(0);
-	return;
+   SET_CARRY(0);
+   return;
 }
 
 void mos6502::Op_CLD(uint16_t src)
 {
-	SET_DECIMAL(0);
-	return;
+   SET_DECIMAL(0);
+   return;
 }
 
 void mos6502::Op_CLI(uint16_t src)
 {
-	SET_INTERRUPT(0);
-	return;
+   SET_INTERRUPT(0);
+   return;
 }
 
 void mos6502::Op_CLV(uint16_t src)
 {
-	SET_OVERFLOW(0);
-	return;
+   SET_OVERFLOW(0);
+   return;
 }
 
 void mos6502::Op_CMP(uint16_t src)
 {
-	unsigned int tmp = A - Read(src);
-	SET_CARRY(tmp < 0x100);
-	SET_NEGATIVE(tmp & 0x80);
-	SET_ZERO(!(tmp & 0xFF));
-	return;
+   unsigned int tmp = A - Read(src);
+   SET_CARRY(tmp < 0x100);
+   SET_NEGATIVE(tmp & 0x80);
+   SET_ZERO(!(tmp & 0xFF));
+   return;
 }
 
 void mos6502::Op_CPX(uint16_t src)
 {
-	unsigned int tmp = X - Read(src);
-	SET_CARRY(tmp < 0x100);
-	SET_NEGATIVE(tmp & 0x80);
-	SET_ZERO(!(tmp & 0xFF));
-	return;
+   unsigned int tmp = X - Read(src);
+   SET_CARRY(tmp < 0x100);
+   SET_NEGATIVE(tmp & 0x80);
+   SET_ZERO(!(tmp & 0xFF));
+   return;
 }
 
 void mos6502::Op_CPY(uint16_t src)
 {
-	unsigned int tmp = Y - Read(src);
-	SET_CARRY(tmp < 0x100);
-	SET_NEGATIVE(tmp & 0x80);
-	SET_ZERO(!(tmp & 0xFF));
-	return;
+   unsigned int tmp = Y - Read(src);
+   SET_CARRY(tmp < 0x100);
+   SET_NEGATIVE(tmp & 0x80);
+   SET_ZERO(!(tmp & 0xFF));
+   return;
 }
 
 void mos6502::Op_DEC(uint16_t src)
 {
-	uint8_t m = Read(src);
-	m = (m - 1) & 0xFF;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	Write(src, m);
-	return;
+   uint8_t m = Read(src);
+   m = (m - 1) & 0xFF;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   Write(src, m);
+   return;
 }
 
 void mos6502::Op_DEX(uint16_t src)
 {
-	uint8_t m = X;
-	m = (m - 1) & 0xFF;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	X = m;
-	return;
+   uint8_t m = X;
+   m = (m - 1) & 0xFF;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   X = m;
+   return;
 }
 
 void mos6502::Op_DEY(uint16_t src)
 {
-	uint8_t m = Y;
-	m = (m - 1) & 0xFF;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	Y = m;
-	return;
+   uint8_t m = Y;
+   m = (m - 1) & 0xFF;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   Y = m;
+   return;
 }
 
 void mos6502::Op_EOR(uint16_t src)
 {
-	uint8_t m = Read(src);
-	m = A ^ m;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	A = m;
+   uint8_t m = Read(src);
+   m = A ^ m;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   A = m;
 }
 
 void mos6502::Op_INC(uint16_t src)
 {
-	uint8_t m = Read(src);
-	m = (m + 1) & 0xFF;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	Write(src, m);
+   uint8_t m = Read(src);
+   m = (m + 1) & 0xFF;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   Write(src, m);
 }
 
 void mos6502::Op_INX(uint16_t src)
 {
-	uint8_t m = X;
-	m = (m + 1) & 0xFF;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	X = m;
+   uint8_t m = X;
+   m = (m + 1) & 0xFF;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   X = m;
 }
 
 void mos6502::Op_INY(uint16_t src)
 {
-	uint8_t m = Y;
-	m = (m + 1) & 0xFF;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	Y = m;
+   uint8_t m = Y;
+   m = (m + 1) & 0xFF;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   Y = m;
 }
 
 void mos6502::Op_JMP(uint16_t src)
 {
-	pc = src;
+   pc = src;
 }
 
 void mos6502::Op_JSR(uint16_t src)
 {
-	pc--;
-	StackPush((pc >> 8) & 0xFF);
-	StackPush(pc & 0xFF);
-	pc = src;
+   pc--;
+   StackPush((pc >> 8) & 0xFF);
+   StackPush(pc & 0xFF);
+   pc = src;
 }
 
 void mos6502::Op_LDA(uint16_t src)
 {
-	uint8_t m = Read(src);
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	A = m;
+   uint8_t m = Read(src);
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   A = m;
 }
 
 void mos6502::Op_LDX(uint16_t src)
 {
-	uint8_t m = Read(src);
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	X = m;
+   uint8_t m = Read(src);
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   X = m;
 }
 
 void mos6502::Op_LDY(uint16_t src)
 {
-	uint8_t m = Read(src);
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	Y = m;
+   uint8_t m = Read(src);
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   Y = m;
 }
 
 void mos6502::Op_LSR(uint16_t src)
 {
-	uint8_t m = Read(src);
-	SET_CARRY(m & 0x01);
-	m >>= 1;
-	SET_NEGATIVE(0);
-	SET_ZERO(!m);
-	Write(src, m);
+   uint8_t m = Read(src);
+   SET_CARRY(m & 0x01);
+   m >>= 1;
+   SET_NEGATIVE(0);
+   SET_ZERO(!m);
+   Write(src, m);
 }
 
 void mos6502::Op_LSR_ACC(uint16_t src)
 {
-	uint8_t m = A;
-	SET_CARRY(m & 0x01);
-	m >>= 1;
-	SET_NEGATIVE(0);
-	SET_ZERO(!m);
-	A = m;
+   uint8_t m = A;
+   SET_CARRY(m & 0x01);
+   m >>= 1;
+   SET_NEGATIVE(0);
+   SET_ZERO(!m);
+   A = m;
 }
 
 void mos6502::Op_NOP(uint16_t src)
 {
-	return;
+   return;
 }
 
 void mos6502::Op_ORA(uint16_t src)
 {
-	uint8_t m = Read(src);
-	m = A | m;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	A = m;
+   uint8_t m = Read(src);
+   m = A | m;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   A = m;
 }
 
 void mos6502::Op_PHA(uint16_t src)
 {
-	StackPush(A);
-	return;
+   StackPush(A);
+   return;
 }
 
 void mos6502::Op_PHP(uint16_t src)
 {
-	StackPush(status | CONSTANT | BREAK);
-	return;
+   StackPush(status | CONSTANT | BREAK);
+   return;
 }
 
 void mos6502::Op_PLA(uint16_t src)
 {
-	A = StackPop();
-	SET_NEGATIVE(A & 0x80);
-	SET_ZERO(!A);
-	return;
+   A = StackPop();
+   SET_NEGATIVE(A & 0x80);
+   SET_ZERO(!A);
+   return;
 }
 
 void mos6502::Op_PLP(uint16_t src)
 {
-	status = StackPop() | CONSTANT | BREAK;
-	//SET_CONSTANT(1);
-	return;
+   status = StackPop() | CONSTANT | BREAK;
+   //SET_CONSTANT(1);
+   return;
 }
 
 void mos6502::Op_ROL(uint16_t src)
 {
-	uint16_t m = Read(src);
-	m <<= 1;
-	if (IF_CARRY()) m |= 0x01;
-	SET_CARRY(m > 0xFF);
-	m &= 0xFF;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	Write(src, m);
-	return;
+   uint16_t m = Read(src);
+   m <<= 1;
+   if (IF_CARRY()) m |= 0x01;
+   SET_CARRY(m > 0xFF);
+   m &= 0xFF;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   Write(src, m);
+   return;
 }
 
 void mos6502::Op_ROL_ACC(uint16_t src)
 {
-	uint16_t m = A;
-	m <<= 1;
-	if (IF_CARRY()) m |= 0x01;
-	SET_CARRY(m > 0xFF);
-	m &= 0xFF;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	A = m;
-	return;
+   uint16_t m = A;
+   m <<= 1;
+   if (IF_CARRY()) m |= 0x01;
+   SET_CARRY(m > 0xFF);
+   m &= 0xFF;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   A = m;
+   return;
 }
 
 void mos6502::Op_ROR(uint16_t src)
 {
-	uint16_t m = Read(src);
-	if (IF_CARRY()) m |= 0x100;
-	SET_CARRY(m & 0x01);
-	m >>= 1;
-	m &= 0xFF;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	Write(src, m);
-	return;
+   uint16_t m = Read(src);
+   if (IF_CARRY()) m |= 0x100;
+   SET_CARRY(m & 0x01);
+   m >>= 1;
+   m &= 0xFF;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   Write(src, m);
+   return;
 }
 
 void mos6502::Op_ROR_ACC(uint16_t src)
 {
-	uint16_t m = A;
-	if (IF_CARRY()) m |= 0x100;
-	SET_CARRY(m & 0x01);
-	m >>= 1;
-	m &= 0xFF;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	A = m;
-	return;
+   uint16_t m = A;
+   if (IF_CARRY()) m |= 0x100;
+   SET_CARRY(m & 0x01);
+   m >>= 1;
+   m &= 0xFF;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   A = m;
+   return;
 }
 
 void mos6502::Op_RTI(uint16_t src)
 {
-	uint8_t lo, hi;
+   uint8_t lo, hi;
 
-	status = StackPop() | CONSTANT | BREAK;
+   status = StackPop() | CONSTANT | BREAK;
 
-	lo = StackPop();
-	hi = StackPop();
+   lo = StackPop();
+   hi = StackPop();
 
-	pc = (hi << 8) | lo;
-	return;
+   pc = (hi << 8) | lo;
+   return;
 }
 
 void mos6502::Op_RTS(uint16_t src)
 {
-	uint8_t lo, hi;
+   uint8_t lo, hi;
 
-	lo = StackPop();
-	hi = StackPop();
+   lo = StackPop();
+   hi = StackPop();
 
-	pc = ((hi << 8) | lo) + 1;
-	return;
+   pc = ((hi << 8) | lo) + 1;
+   return;
 }
 
 void mos6502::Op_SBC(uint16_t src)
 {
-	uint8_t m = Read(src);
-	unsigned int tmp = A - m - (IF_CARRY() ? 0 : 1);
-	SET_NEGATIVE(tmp & 0x80);
-	SET_ZERO(!(tmp & 0xFF));
-	SET_OVERFLOW(((A ^ tmp) & 0x80) && ((A ^ m) & 0x80));
+   uint8_t m = Read(src);
+   unsigned int tmp = A - m - (IF_CARRY() ? 0 : 1);
+   SET_NEGATIVE(tmp & 0x80);
+   SET_ZERO(!(tmp & 0xFF));
+   SET_OVERFLOW(((A ^ tmp) & 0x80) && ((A ^ m) & 0x80));
 
-	if (IF_DECIMAL())
-	{
-		if ( ((A & 0x0F) - (IF_CARRY() ? 0 : 1)) < (m & 0x0F)) tmp -= 6;
-		if (tmp > 0x99)
-		{
-			tmp -= 0x60;
-		}
-	}
-	SET_CARRY(tmp < 0x100);
-	A = (tmp & 0xFF);
-	return;
+   if (IF_DECIMAL())
+   {
+      if ( ((A & 0x0F) - (IF_CARRY() ? 0 : 1)) < (m & 0x0F)) tmp -= 6;
+      if (tmp > 0x99)
+      {
+         tmp -= 0x60;
+      }
+   }
+   SET_CARRY(tmp < 0x100);
+   A = (tmp & 0xFF);
+   return;
 }
 
 void mos6502::Op_SEC(uint16_t src)
 {
-	SET_CARRY(1);
-	return;
+   SET_CARRY(1);
+   return;
 }
 
 void mos6502::Op_SED(uint16_t src)
 {
-	SET_DECIMAL(1);
-	return;
+   SET_DECIMAL(1);
+   return;
 }
 
 void mos6502::Op_SEI(uint16_t src)
 {
-	SET_INTERRUPT(1);
-	return;
+   SET_INTERRUPT(1);
+   return;
 }
 
 void mos6502::Op_STA(uint16_t src)
 {
-	Write(src, A);
-	return;
+   Write(src, A);
+   return;
 }
 
 void mos6502::Op_STX(uint16_t src)
 {
-	Write(src, X);
-	return;
+   Write(src, X);
+   return;
 }
 
 void mos6502::Op_STY(uint16_t src)
 {
-	Write(src, Y);
-	return;
+   Write(src, Y);
+   return;
 }
 
 void mos6502::Op_TAX(uint16_t src)
 {
-	uint8_t m = A;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	X = m;
-	return;
+   uint8_t m = A;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   X = m;
+   return;
 }
 
 void mos6502::Op_TAY(uint16_t src)
 {
-	uint8_t m = A;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	Y = m;
-	return;
+   uint8_t m = A;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   Y = m;
+   return;
 }
 
 void mos6502::Op_TSX(uint16_t src)
 {
-	uint8_t m = sp;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	X = m;
-	return;
+   uint8_t m = sp;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   X = m;
+   return;
 }
 
 void mos6502::Op_TXA(uint16_t src)
 {
-	uint8_t m = X;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	A = m;
-	return;
+   uint8_t m = X;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   A = m;
+   return;
 }
 
 void mos6502::Op_TXS(uint16_t src)
 {
-	sp = X;
-	return;
+   sp = X;
+   return;
 }
 
 void mos6502::Op_TYA(uint16_t src)
 {
-	uint8_t m = Y;
-	SET_NEGATIVE(m & 0x80);
-	SET_ZERO(!m);
-	A = m;
-	return;
+   uint8_t m = Y;
+   SET_NEGATIVE(m & 0x80);
+   SET_ZERO(!m);
+   A = m;
+   return;
 }

--- a/mos6502.h
+++ b/mos6502.h
@@ -8,183 +8,189 @@
 
 #pragma once
 #include <stdint.h>
+#include <stdbool.h>
 
 class mos6502
 {
 private:
-    // register reset values
-    uint8_t reset_A;
-    uint8_t reset_X;
-    uint8_t reset_Y;
-    uint8_t reset_sp;
-    uint8_t reset_status;
+      // register reset values
+      uint8_t reset_A;
+      uint8_t reset_X;
+      uint8_t reset_Y;
+      uint8_t reset_sp;
+      uint8_t reset_status;
 
-	// registers
-	uint8_t A; // accumulator
-	uint8_t X; // X-index
-	uint8_t Y; // Y-index
+      // registers
+      uint8_t A; // accumulator
+      uint8_t X; // X-index
+      uint8_t Y; // Y-index
 
-	// stack pointer
-	uint8_t sp;
+      // stack pointer
+      uint8_t sp;
 
-	// program counter
-	uint16_t pc;
+      // program counter
+      uint16_t pc;
 
-	// status register
-	uint8_t status;
+      // status register
+      uint8_t status;
 
-	typedef void (mos6502::*CodeExec)(uint16_t);
-	typedef uint16_t (mos6502::*AddrExec)();
+      typedef void (mos6502::*CodeExec)(uint16_t);
+      typedef uint16_t (mos6502::*AddrExec)();
 
-	struct Instr
-	{
-		AddrExec addr;
-		CodeExec code;
-		uint8_t cycles;
-	};
+      struct Instr
+      {
+         AddrExec addr;
+         const char * saddr;
+         CodeExec code;
+         const char * scode;
+         uint8_t cycles;
+         bool penalty;
+      };
 
-	static Instr InstrTable[256];
+      static Instr InstrTable[256];
 
-	void Exec(Instr i);
+      void Exec(Instr i);
 
-	bool illegalOpcode;
+      bool illegalOpcode;
 
-	// addressing modes
-	uint16_t Addr_ACC(); // ACCUMULATOR
-	uint16_t Addr_IMM(); // IMMEDIATE
-	uint16_t Addr_ABS(); // ABSOLUTE
-	uint16_t Addr_ZER(); // ZERO PAGE
-	uint16_t Addr_ZEX(); // INDEXED-X ZERO PAGE
-	uint16_t Addr_ZEY(); // INDEXED-Y ZERO PAGE
-	uint16_t Addr_ABX(); // INDEXED-X ABSOLUTE
-	uint16_t Addr_ABY(); // INDEXED-Y ABSOLUTE
-	uint16_t Addr_IMP(); // IMPLIED
-	uint16_t Addr_REL(); // RELATIVE
-	uint16_t Addr_INX(); // INDEXED-X INDIRECT
-	uint16_t Addr_INY(); // INDEXED-Y INDIRECT
-	uint16_t Addr_ABI(); // ABSOLUTE INDIRECT
+      bool crossed;
 
-	// opcodes (grouped as per datasheet)
-	void Op_ADC(uint16_t src);
-	void Op_AND(uint16_t src);
-	void Op_ASL(uint16_t src); 	void Op_ASL_ACC(uint16_t src);
-	void Op_BCC(uint16_t src);
-	void Op_BCS(uint16_t src);
+      // addressing modes
+      uint16_t Addr_ACC(); // ACCUMULATOR
+      uint16_t Addr_IMM(); // IMMEDIATE
+      uint16_t Addr_ABS(); // ABSOLUTE
+      uint16_t Addr_ZER(); // ZERO PAGE
+      uint16_t Addr_ZEX(); // INDEXED-X ZERO PAGE
+      uint16_t Addr_ZEY(); // INDEXED-Y ZERO PAGE
+      uint16_t Addr_ABX(); // INDEXED-X ABSOLUTE
+      uint16_t Addr_ABY(); // INDEXED-Y ABSOLUTE
+      uint16_t Addr_IMP(); // IMPLIED
+      uint16_t Addr_REL(); // RELATIVE
+      uint16_t Addr_INX(); // INDEXED-X INDIRECT
+      uint16_t Addr_INY(); // INDEXED-Y INDIRECT
+      uint16_t Addr_ABI(); // ABSOLUTE INDIRECT
 
-	void Op_BEQ(uint16_t src);
-	void Op_BIT(uint16_t src);
-	void Op_BMI(uint16_t src);
-	void Op_BNE(uint16_t src);
-	void Op_BPL(uint16_t src);
+      // opcodes (grouped as per datasheet)
+      void Op_ADC(uint16_t src);
+      void Op_AND(uint16_t src);
+      void Op_ASL(uint16_t src);    void Op_ASL_ACC(uint16_t src);
+      void Op_BCC(uint16_t src);
+      void Op_BCS(uint16_t src);
 
-	void Op_BRK(uint16_t src);
-	void Op_BVC(uint16_t src);
-	void Op_BVS(uint16_t src);
-	void Op_CLC(uint16_t src);
-	void Op_CLD(uint16_t src);
+      void Op_BEQ(uint16_t src);
+      void Op_BIT(uint16_t src);
+      void Op_BMI(uint16_t src);
+      void Op_BNE(uint16_t src);
+      void Op_BPL(uint16_t src);
 
-	void Op_CLI(uint16_t src);
-	void Op_CLV(uint16_t src);
-	void Op_CMP(uint16_t src);
-	void Op_CPX(uint16_t src);
-	void Op_CPY(uint16_t src);
+      void Op_BRK(uint16_t src);
+      void Op_BVC(uint16_t src);
+      void Op_BVS(uint16_t src);
+      void Op_CLC(uint16_t src);
+      void Op_CLD(uint16_t src);
 
-	void Op_DEC(uint16_t src);
-	void Op_DEX(uint16_t src);
-	void Op_DEY(uint16_t src);
-	void Op_EOR(uint16_t src);
-	void Op_INC(uint16_t src);
+      void Op_CLI(uint16_t src);
+      void Op_CLV(uint16_t src);
+      void Op_CMP(uint16_t src);
+      void Op_CPX(uint16_t src);
+      void Op_CPY(uint16_t src);
 
-	void Op_INX(uint16_t src);
-	void Op_INY(uint16_t src);
-	void Op_JMP(uint16_t src);
-	void Op_JSR(uint16_t src);
-	void Op_LDA(uint16_t src);
+      void Op_DEC(uint16_t src);
+      void Op_DEX(uint16_t src);
+      void Op_DEY(uint16_t src);
+      void Op_EOR(uint16_t src);
+      void Op_INC(uint16_t src);
 
-	void Op_LDX(uint16_t src);
-	void Op_LDY(uint16_t src);
-	void Op_LSR(uint16_t src); 	void Op_LSR_ACC(uint16_t src);
-	void Op_NOP(uint16_t src);
-	void Op_ORA(uint16_t src);
+      void Op_INX(uint16_t src);
+      void Op_INY(uint16_t src);
+      void Op_JMP(uint16_t src);
+      void Op_JSR(uint16_t src);
+      void Op_LDA(uint16_t src);
 
-	void Op_PHA(uint16_t src);
-	void Op_PHP(uint16_t src);
-	void Op_PLA(uint16_t src);
-	void Op_PLP(uint16_t src);
-	void Op_ROL(uint16_t src); 	void Op_ROL_ACC(uint16_t src);
+      void Op_LDX(uint16_t src);
+      void Op_LDY(uint16_t src);
+      void Op_LSR(uint16_t src);    void Op_LSR_ACC(uint16_t src);
+      void Op_NOP(uint16_t src);
+      void Op_ORA(uint16_t src);
 
-	void Op_ROR(uint16_t src);	void Op_ROR_ACC(uint16_t src);
-	void Op_RTI(uint16_t src);
-	void Op_RTS(uint16_t src);
-	void Op_SBC(uint16_t src);
-	void Op_SEC(uint16_t src);
-	void Op_SED(uint16_t src);
+      void Op_PHA(uint16_t src);
+      void Op_PHP(uint16_t src);
+      void Op_PLA(uint16_t src);
+      void Op_PLP(uint16_t src);
+      void Op_ROL(uint16_t src);    void Op_ROL_ACC(uint16_t src);
 
-	void Op_SEI(uint16_t src);
-	void Op_STA(uint16_t src);
-	void Op_STX(uint16_t src);
-	void Op_STY(uint16_t src);
-	void Op_TAX(uint16_t src);
+      void Op_ROR(uint16_t src);    void Op_ROR_ACC(uint16_t src);
+      void Op_RTI(uint16_t src);
+      void Op_RTS(uint16_t src);
+      void Op_SBC(uint16_t src);
+      void Op_SEC(uint16_t src);
+      void Op_SED(uint16_t src);
 
-	void Op_TAY(uint16_t src);
-	void Op_TSX(uint16_t src);
-	void Op_TXA(uint16_t src);
-	void Op_TXS(uint16_t src);
-	void Op_TYA(uint16_t src);
+      void Op_SEI(uint16_t src);
+      void Op_STA(uint16_t src);
+      void Op_STX(uint16_t src);
+      void Op_STY(uint16_t src);
+      void Op_TAX(uint16_t src);
 
-	void Op_ILLEGAL(uint16_t src);
+      void Op_TAY(uint16_t src);
+      void Op_TSX(uint16_t src);
+      void Op_TXA(uint16_t src);
+      void Op_TXS(uint16_t src);
+      void Op_TYA(uint16_t src);
 
-	// IRQ, reset, NMI vectors
-	static const uint16_t irqVectorH = 0xFFFF;
-	static const uint16_t irqVectorL = 0xFFFE;
-	static const uint16_t rstVectorH = 0xFFFD;
-	static const uint16_t rstVectorL = 0xFFFC;
-	static const uint16_t nmiVectorH = 0xFFFB;
-	static const uint16_t nmiVectorL = 0xFFFA;
+      void Op_ILLEGAL(uint16_t src);
 
-	// read/write/clock-cycle callbacks
-	typedef void (*BusWrite)(uint16_t, uint8_t);
-	typedef uint8_t (*BusRead)(uint16_t);
-	typedef void (*ClockCycle)(mos6502*);
-	BusRead Read;
-	BusWrite Write;
-	ClockCycle Cycle;
+      // IRQ, reset, NMI vectors
+      static const uint16_t irqVectorH = 0xFFFF;
+      static const uint16_t irqVectorL = 0xFFFE;
+      static const uint16_t rstVectorH = 0xFFFD;
+      static const uint16_t rstVectorL = 0xFFFC;
+      static const uint16_t nmiVectorH = 0xFFFB;
+      static const uint16_t nmiVectorL = 0xFFFA;
 
-	// stack operations
-	inline void StackPush(uint8_t byte);
-	inline uint8_t StackPop();
+      // read/write/clock-cycle callbacks
+      typedef void (*BusWrite)(uint16_t, uint8_t);
+      typedef uint8_t (*BusRead)(uint16_t);
+      typedef void (*ClockCycle)(mos6502*);
+      BusRead Read;
+      BusWrite Write;
+      ClockCycle Cycle;
+
+      // stack operations
+      inline void StackPush(uint8_t byte);
+      inline uint8_t StackPop();
 
 public:
-	enum CycleMethod {
-		INST_COUNT,
-		CYCLE_COUNT,
-	};
-	mos6502(BusRead r, BusWrite w, ClockCycle c = nullptr);
-	void NMI();
-	void IRQ();
-	void Reset();
-	void Run(
-		int32_t cycles,
-		uint64_t& cycleCount,
-		CycleMethod cycleMethod = CYCLE_COUNT);
-	void RunEternally(); // until it encounters a illegal opcode
-						 // useful when running e.g. WOZ Monitor
-						 // no need to worry about cycle exhaus-
-						 // tion
-    uint16_t GetPC();
-    uint8_t GetS();
-    uint8_t GetP();
-    uint8_t GetA();
-    uint8_t GetX();
-    uint8_t GetY();
-    void SetResetS(uint8_t value);
-    void SetResetP(uint8_t value);
-    void SetResetA(uint8_t value);
-    void SetResetX(uint8_t value);
-    void SetResetY(uint8_t value);
-    uint8_t GetResetS();
-    uint8_t GetResetP();
-    uint8_t GetResetA();
-    uint8_t GetResetX();
-    uint8_t GetResetY();
+      enum CycleMethod {
+         INST_COUNT,
+         CYCLE_COUNT,
+      };
+      mos6502(BusRead r, BusWrite w, ClockCycle c = nullptr);
+      void NMI();
+      void IRQ();
+      void Reset();
+      void Run(
+            int32_t cycles,
+            uint64_t& cycleCount,
+            CycleMethod cycleMethod = CYCLE_COUNT);
+      void RunEternally(); // until it encounters a illegal opcode
+                           // useful when running e.g. WOZ Monitor
+                           // no need to worry about cycle exhaus-
+                           // tion
+      uint16_t GetPC();
+      uint8_t GetS();
+      uint8_t GetP();
+      uint8_t GetA();
+      uint8_t GetX();
+      uint8_t GetY();
+      void SetResetS(uint8_t value);
+      void SetResetP(uint8_t value);
+      void SetResetA(uint8_t value);
+      void SetResetX(uint8_t value);
+      void SetResetY(uint8_t value);
+      uint8_t GetResetS();
+      uint8_t GetResetP();
+      uint8_t GetResetA();
+      uint8_t GetResetX();
+      uint8_t GetResetY();
 };


### PR DESCRIPTION
fixed two cycle count typos,
refactored InstrTable population,
account for page boundary crossing penalties.

should now be cycle accurate.